### PR TITLE
Update README.md

### DIFF
--- a/fa/django_urls/README.md
+++ b/fa/django_urls/README.md
@@ -56,8 +56,8 @@ urlpatterns = [
 {% filename %}mysite/urls.py{% endfilename %}
 
 ```python
-from django.contrib import path, include
-from django.urls import admin
+from django.contrib import path
+from django.urls import admin, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
The **include** should be imported from **django.urls**

Changes in this pull request:

- from django.contrib import path, include ---  it doesn't import include
